### PR TITLE
This simple fix, handles all the unicode characters.

### DIFF
--- a/src/facegraph/canvas.py
+++ b/src/facegraph/canvas.py
@@ -15,7 +15,7 @@ def b64url_decode(encoded):
     
     # The padding should round the length of the string up to a multiple of 4.
     padding_fixed = encoded + (((4 - (len(encoded) % 4)) % 4) * '=')
-    return base64.urlsafe_b64decode(padding_fixed)
+    return base64.urlsafe_b64decode(str(padding_fixed))
 
 
 def decode_signed_request(app_secret, signed_request):


### PR DESCRIPTION
Fix for "base64 does not properly handle unicode strings" also in: http://bugs.python.org/issue4329
